### PR TITLE
add live reload support.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 const fsbx = require("fuse-box");
 const gulp = require("gulp");
 const runSequence = require('run-sequence');
+const server = require('gulp-server-livereload');
 
 
 // Create FuseBox Instance
@@ -33,6 +34,14 @@ gulp.task("build", () => {
     return fuseBox.bundle(">index.jsx +react-dom");
 })
 gulp.task('start', ['build'], function() {
+    gulp.src('')
+        .pipe(server({
+            livereload: {
+                enable: true,
+                filter: (filePath, cb) => cb(filePath.endsWith('build/out.js'))
+            },
+            open: true
+        }));
     gulp.watch('src/**/*.**', () => {
         runSequence('build');
     });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-preset-latest": "^6.16.0",
     "fuse-box": "^1.3.40",
     "gulp": "^3.9.1",
+    "gulp-server-livereload": "^1.9.2",
     "run-sequence": "^1.2.2",
     "typescript": "^2.1.4"
   }


### PR DESCRIPTION
1. `npm i` to install dependences.
2. `gulp start` to start a dev server with live reload.